### PR TITLE
fix: normalize OCI registry URL casing and improve tag handling in Makefile

### DIFF
--- a/.github/workflows/flux-push.yaml
+++ b/.github/workflows/flux-push.yaml
@@ -30,18 +30,22 @@ jobs:
 
       - name: Push OCI artifact
         id: push
+        env:
+          REPO: ${{ github.repository }}
         run: |
+          REPO_LC=$(echo "$REPO" | tr '[:upper:]' '[:lower:]')
           TAG=${GITHUB_REF_NAME#v}
-          digest=$(flux push artifact oci://ghcr.io/${{ github.repository }}/releases:${TAG} \
+          digest=$(flux push artifact oci://ghcr.io/${REPO_LC}/releases:${TAG} \
             --path="./releases" \
             --source="${{ github.repositoryUrl }}" \
             --revision="${{ github.ref_name }}@sha1:${{ github.sha }}" \
             --output json | jq -r '.digest')
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "digest=${digest}" >> $GITHUB_OUTPUT
+          echo "repo=${REPO_LC}" >> $GITHUB_OUTPUT
 
       - name: Tag artifact
         run: |
           flux tag artifact \
-            oci://ghcr.io/${{ github.repository }}/releases:${{ steps.push.outputs.tag }}@${{ steps.push.outputs.digest }} \
+            oci://ghcr.io/${{ steps.push.outputs.repo }}/releases:${{ steps.push.outputs.tag }}@${{ steps.push.outputs.digest }} \
             --tag latest

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ down:
 
 push:
 	@git fetch origin --tags --force
-	$(eval TAG=$(shell git tag --list 'v*' | sort -V | tail -1 | sed 's/^v//' || echo "0.0.0"))
+	$(eval TAG=$(shell git tag --list 'v*' | sort -V | tail -1 | sed 's/^v//'))
+	$(eval TAG=$(if $(TAG),$(TAG),0.0.0))
 	$(eval MAJOR=$(shell echo $(TAG) | cut -d. -f1))
 	$(eval MINOR=$(shell echo $(TAG) | cut -d. -f2))
 	$(eval PATCH=$(shell echo $(TAG) | cut -d. -f3))


### PR DESCRIPTION
The CI workflow now lowercases the repository name before building the OCI URL, preventing push/tag failures on repos with mixed-case names (GitHub Packages requires lowercase).

Also fixes the Makefile tag-parsing fallback so an empty tag list correctly defaults to 0.0.0 instead of producing a broken sed substitution.