### PR TITLE
feat: configure kagent OpenAI provider with secret reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,38 @@ kubectl get svc -n agentgateway-system  # grab the LoadBalancer IP
 
 Point your AI app at the gateway IP on port 80.
 
+## LLM secret setup
+
+kagent reads the OpenAI API key from a Kubernetes Secret.
+
+1. Export your key (interactive, won't echo):
+
+```bash
+read -s OPENAI_API_KEY && export OPENAI_API_KEY
+```
+
+2. Create the secret:
+
+```bash
+kubectl create secret generic kagent-openai \
+  --from-literal=OPENAI_API_KEY="$OPENAI_API_KEY" \
+  -n kagent \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+3. Restart kagent so it picks up the secret:
+
+```bash
+kubectl rollout restart deployment/kagent-controller -n kagent
+```
+
+4. Verify:
+
+```bash
+kubectl get secret -n kagent kagent-openai
+kubectl get pods -n kagent
+```
+
 ## How it works
 
 ```

--- a/releases/kagent.yaml
+++ b/releases/kagent.yaml
@@ -67,7 +67,10 @@ spec:
     providers:
       default: openAI
       openAI:
-        apiKey: OPENAI_API_KEY
+        provider: OpenAI
+        model: "gpt-5-mini"
+        apiKeySecretRef: kagent-openai
+        apiKeySecretKey: OPENAI_API_KEY
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant


### PR DESCRIPTION
Switch kagent from a plain apiKey field to proper secret-backed config:
- Set provider to OpenAI with gpt-5-mini model
- Reference API key from Kubernetes Secret (kagent-openai)
- Add README section documenting LLM secret setup steps

This avoids hardcoding API keys in the HelmRelease values and follows the standard kagent secretRef pattern for credential management.