### PR TITLE
fix: replace dpkg/wget with portable uname/curl for cloud-provider-kind install

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -43,13 +43,30 @@ cd ..
 
 # Install cloud-provider-kind (LoadBalancer support)
 log "Installing cloud-provider-kind..."
-ARCH=$(dpkg --print-architecture)
-wget -q "https://github.com/kubernetes-sigs/cloud-provider-kind/releases/download/v0.6.0/cloud-provider-kind_0.6.0_linux_${ARCH}.tar.gz" \
-  -O /tmp/cloud-provider-kind.tar.gz
-tar -xzf /tmp/cloud-provider-kind.tar.gz -C /tmp cloud-provider-kind
-rm /tmp/cloud-provider-kind.tar.gz
-nohup /tmp/cloud-provider-kind > /tmp/cloud-provider-kind.log 2>&1 &
-log "cloud-provider-kind started (pid $!)"
+case "$(uname -s)" in
+  Linux)  CPK_OS=linux ;;
+  Darwin) CPK_OS=darwin ;;
+  *)
+    log "Unsupported OS: $(uname -s); skipping cloud-provider-kind"
+    CPK_OS=
+    ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64) CPK_ARCH=amd64 ;;
+  arm64|aarch64) CPK_ARCH=arm64 ;;
+  *)
+    log "Unsupported arch: $(uname -m); skipping cloud-provider-kind"
+    CPK_ARCH=
+    ;;
+esac
+if [[ -n "${CPK_OS:-}" && -n "${CPK_ARCH:-}" ]]; then
+  CPK_URL="https://github.com/kubernetes-sigs/cloud-provider-kind/releases/download/v0.6.0/cloud-provider-kind_0.6.0_${CPK_OS}_${CPK_ARCH}.tar.gz"
+  curl -fsSL "$CPK_URL" -o /tmp/cloud-provider-kind.tar.gz
+  tar -xzf /tmp/cloud-provider-kind.tar.gz -C /tmp cloud-provider-kind
+  rm -f /tmp/cloud-provider-kind.tar.gz
+  nohup /tmp/cloud-provider-kind > /tmp/cloud-provider-kind.log 2>&1 &
+  log "cloud-provider-kind started (pid $!)"
+fi
 
 
 log "=== setup complete ==="


### PR DESCRIPTION
**The problem with the old code**
The original cloud-provider-kind installation block had three hard dependencies that made the script Linux-only and Debian-specific:
 1. dpkg only exists on Debian/Ubuntu; crashes on macOS and any non-Debian Linux
 2. URL hardcoded linux_${ARCH} - Never downloads the Darwin binary
 3. wget - Not installed by default on macOS

CONTRIBUTING.md explicitly states: "Requirements: Docker, macOS or Linux" - so the script was broken on a first-class supported platform.

**Actual changes:**

1. uname -s for OS, uname -m for arch

2. uname is POSIX - available on every Unix. It correctly identifies Darwin (macOS) and Linux without requiring any package manager. The arm64|aarch64 alias handles the fact that Linux and macOS report the same hardware differently.

3. curl instead of wget
curl ships with macOS by default; wget does not. Since the rest of setup.sh already uses curl (OpenTofu install, k9s install), this keeps the script consistent and removes the wget dependency entirely.

4. Guard block if [[ -n "${CPK_OS:-}" && -n "${CPK_ARCH:-}" ]]
If uname returns an unrecognised OS or arch, the script now logs a warning and continues rather than silently downloading a wrong binary or aborting with a non-zero exit (which set -euo pipefail would turn into a fatal failure). This matches the project's goal of a reliable single-command bootstrap.

5. rm -f instead of rm
Minor but deliberate: -f prevents a spurious failure if the tarball wasn't created due to a download error on a partially-failed run.
